### PR TITLE
Changing the master and slave jargon

### DIFF
--- a/Test/admin.py
+++ b/Test/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 # Register your models here.
-from Test.models import Division, IndustryTypeMaster, IndustryTypeSlave, CompanyInfo, District, Thana
+from Test.models import Division, IndustryTypeMain, IndustryTypeSubordinate, CompanyInfo, District, Thana
 
 
 class DivisionAdmin(admin.ModelAdmin):
@@ -25,22 +25,22 @@ class ThanaAdmin(admin.ModelAdmin):
 admin.site.register(Thana, ThanaAdmin)
 
 
-class IndustryTypeMasterAdmin(admin.ModelAdmin):
+class IndustryTypeMainAdmin(admin.ModelAdmin):
     list_display = ['name']
 
 
-admin.site.register(IndustryTypeMaster, IndustryTypeMasterAdmin)
+admin.site.register(IndustryTypeMain, IndustryTypeMainAdmin)
 
 
-class IndustryTypeSlaveAdmin(admin.ModelAdmin):
-    list_display = ['name', 'industrytypemaster']
+class IndustryTypeSubordinateAdmin(admin.ModelAdmin):
+    list_display = ['name', 'industrytypemain']
 
 
-admin.site.register(IndustryTypeSlave, IndustryTypeSlaveAdmin)
+admin.site.register(IndustryTypeSubordinate, IndustryTypeSubordinateAdmin)
 
 
 class CompanyInfoAdmin(admin.ModelAdmin):
-    list_display = ['company_name', 'country', 'division', 'get_industrytypeslave', 'user']
+    list_display = ['company_name', 'country', 'division', 'get_industrytypesubordinate', 'user']
 
 
 admin.site.register(CompanyInfo, CompanyInfoAdmin)

--- a/Test/migrations/0001_initial.py
+++ b/Test/migrations/0001_initial.py
@@ -29,7 +29,7 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='IndustryTypeMaster',
+            name='IndustryTypeMain',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=200)),
@@ -44,11 +44,11 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='IndustryTypeSlave',
+            name='IndustryTypeSubordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=200)),
-                ('industrytypemaster', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='Test.IndustryTypeMaster')),
+                ('industrytypemain', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='Test.IndustryTypeMain')),
             ],
         ),
         migrations.AddField(
@@ -63,7 +63,7 @@ class Migration(migrations.Migration):
                 ('company_name', models.CharField(blank=True, default=None, max_length=200)),
                 ('country', models.CharField(max_length=200)),
                 ('division', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='Test.Division')),
-                ('industrytypeslave', models.ManyToManyField(to='Test.IndustryTypeSlave')),
+                ('industrytypesubordinate', models.ManyToManyField(to='Test.IndustryTypeSubordinate')),
                 ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
         ),

--- a/Test/models.py
+++ b/Test/models.py
@@ -26,16 +26,16 @@ class Thana(models.Model):
         return self.name
 
 
-class IndustryTypeMaster(models.Model):
+class IndustryTypeMain(models.Model):
     name = models.CharField(max_length=200)
 
     def __str__(self):
         return self.name
 
 
-class IndustryTypeSlave(models.Model):
+class IndustryTypeSubordinate(models.Model):
     name = models.CharField(max_length=200)
-    industrytypemaster = models.ForeignKey(IndustryTypeMaster, on_delete=models.CASCADE)
+    industrytypemain = models.ForeignKey(IndustryTypeMain, on_delete=models.CASCADE)
 
     def __str__(self):
         return self.name
@@ -45,11 +45,11 @@ class CompanyInfo(models.Model):
     company_name = models.CharField(max_length=200, default=None, blank=True)
     country = models.CharField(max_length=200)
     division = models.ForeignKey(Division, on_delete=models.CASCADE)
-    industrytypeslave = models.ManyToManyField(IndustryTypeSlave)
+    industrytypesubordinate = models.ManyToManyField(IndustryTypeSubordinate)
     user = models.OneToOneField(User, on_delete=models.CASCADE)
 
     def __str__(self):
         return self.company_name
 
-    def get_industrytypeslave(self):
-        return ",".join([str(p) for p in self.industrytypeslave.all()])
+    def get_industrytypesubordinate(self):
+        return ",".join([str(p) for p in self.industrytypesubordinate.all()])

--- a/Test/views.py
+++ b/Test/views.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
-from Test.models import CompanyInfo, IndustryTypeSlave, IndustryTypeMaster, Division
+from Test.models import CompanyInfo, IndustryTypeSubordinate, IndustryTypeMain, Division
 
 
 @csrf_exempt
@@ -40,14 +40,14 @@ def Registration(request):
         company_name = request.POST.get('company_name')
         country = request.POST.get('country')
         # division = request.POST.get('division')
-        industrytypeslave = request.POST.get('industrytypeslave')
+        industrytypesubordinate = request.POST.get('industrytypesubordinate')
 
         # company info creation
         company_info = CompanyInfo.objects.create(
             company_name=company_name,
             country=country,
             division=division,
-            industrytypeslave=industrytypeslave,
+            industrytypesubordinate=industrytypesubordinate,
             user=user
         )
         return JsonResponse(user_data, safe=False)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.